### PR TITLE
Add ability to run Nessus as a non-root user

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -58,5 +58,5 @@ docker run -dt \
 * **PROXY_AGENT** _(optional)_ - Proxy agent string
 * **ADMIN_USER** _(optional)_ - Username for admin user creation
 * **ADMIN_PASS** _(optional)_ - Password for admin user creation
-* **NO_ROOT** _(optional)_ - Set to "Yes" when wanting to [run Nessus as a non-privileged user](https://docs.tenable.com/nessus/6_9/Content/LinuxNonPrivileged.htm)
+* **NO_ROOT** _(optional)_ - Set to "Yes" when wanting to [run Nessus as a non-privileged user](https://docs.tenable.com/nessus/6_9/Content/LinuxNonPrivileged.htm). You should only use this environment variable if you know _what_ you are doing and _why_ you are doing it.
 * **NON_PRIV_USER** _(optional)_ - If _NO_ROOT_ is set, you may use this to specify a username that will be created and used. If left unset, the default is ```nonprivuser```.

--- a/Readme.md
+++ b/Readme.md
@@ -58,3 +58,5 @@ docker run -dt \
 * **PROXY_AGENT** _(optional)_ - Proxy agent string
 * **ADMIN_USER** _(optional)_ - Username for admin user creation
 * **ADMIN_PASS** _(optional)_ - Password for admin user creation
+* **NO_ROOT** _(optional)_ - Set to "Yes" when wanting to [run Nessus as a non-privileged user](https://docs.tenable.com/nessus/6_9/Content/LinuxNonPrivileged.htm)
+* **NON_PRIV_USER** _(optional)_ - If _NO_ROOT_ is set, you may use this to specify a username that will be created and used. If left unset, the default is ```nonprivuser```.

--- a/nessus.sh
+++ b/nessus.sh
@@ -42,12 +42,13 @@ if [[ -n "${NO_ROOT}" ]];then
     echo "-- Updating files to support --no-root"
     # https://docs.tenable.com/nessus/6_9/Content/LinuxNonPrivileged.htm
     useradd -r $USER
+    usermod -a -G tty $USER # https://github.com/moby/moby/issues/31243#issuecomment-406879017
     setcap "cap_net_admin,cap_net_raw,cap_sys_resource+eip" /opt/nessus/sbin/nessusd
     setcap "cap_net_admin,cap_net_raw,cap_sys_resource+eip" /opt/nessus/sbin/nessus-service
     chmod 750 /opt/nessus/sbin/*
     chown -R $USER:$USER /opt/nessus
     echo "-- Starting the Nessus service with --no-root"
-    su - $USER -c '/opt/nessus/sbin/nessus-service --no-root'
+    su $USER -c '/opt/nessus/sbin/nessus-service --no-root'
 else
     echo "-- Starting the Nessus service"
     /opt/nessus/sbin/nessus-service

--- a/nessus.sh
+++ b/nessus.sh
@@ -28,7 +28,27 @@ if [ -n "${ADMIN_USER}" ] && [ -n "${ADMIN_PASS}" ];then
         echo "-- Creating the administrative user based on the provided settings"
         /usr/bin/nessus_adduser.exp "${ADMIN_USER}" "${ADMIN_PASS}" > /dev/null
     fi
-fi 
+fi
 
-echo "-- Starting the Nessus service"
-/opt/nessus/sbin/nessus-service
+if [[ -n "${NO_ROOT}" ]];then
+    USER=nonprivuser
+    if [[ -n "${NON_PRIV_USER}" ]];then
+        USER="${NON_PRIV_USER}"
+        echo "-- Using user-specified non-privileged user ($USER)"
+    else
+        echo "-- No non-priviledged user specified; using default ($USER)"
+    fi
+
+    echo "-- Updating files to support --no-root"
+    # https://docs.tenable.com/nessus/6_9/Content/LinuxNonPrivileged.htm
+    useradd -r $USER
+    setcap "cap_net_admin,cap_net_raw,cap_sys_resource+eip" /opt/nessus/sbin/nessusd
+    setcap "cap_net_admin,cap_net_raw,cap_sys_resource+eip" /opt/nessus/sbin/nessus-service
+    chmod 750 /opt/nessus/sbin/*
+    chown -R $USER:$USER /opt/nessus
+    echo "-- Starting the Nessus service with --no-root"
+    su - $USER -c '/opt/nessus/sbin/nessus-service --no-root'
+else
+    echo "-- Starting the Nessus service"
+    /opt/nessus/sbin/nessus-service
+fi


### PR DESCRIPTION
This PR modifies ```nessus.sh``` so that it is able to [run Nessus as a non-privileged user](https://docs.tenable.com/nessus/6_9/Content/LinuxNonPrivileged.htm).

This functionality is triggered by setting a new environment variable, ```NO_ROOT```, to anything (just like the ```SECURITYCENTER``` environment variable), but suggests ```Yes``` as the value to use. It also points out that one shouldn't use this functionality unless they know they need and know what they are doing as there are certainly caveats described in the Nessus documentation.

```NON_PRIV_USER``` was also added as an environment variable to allow the user to specify the name of the non-privileged user being created if they so desire.

Both new environment variables and usage instructions were added to the ```Readme.md```.

If this PR is not welcome, that's understandable. I am able to pull this off doing some Dockerfile trickery for my use case. I simply thought that the functionality being baked into your base would make it easier.