### PR TITLE
Adding option to add scanner to scanner groups when created

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,18 @@
 FROM centos:7
 
-ENV LINKING_KEY  ""
-ENV SCANNER_NAME ""
-ENV MANAGER_HOST ""
-ENV MANAGER_PORT ""
-ENV PROXY_HOST   ""
-ENV PROXY_PORT   ""
-ENV PROXY_USER   ""
-ENV PROXY_PASS   ""
-ENV PROXY_AGENT  ""
-ENV LICENSE      ""
-ENV ADMIN_USER   "admin"
-ENV ADMIN_PASS   ""
+ENV LINKING_KEY     ""
+ENV SCANNER_NAME    ""
+ENV SCANNER_GROUPS  ""
+ENV MANAGER_HOST    ""
+ENV MANAGER_PORT    ""
+ENV PROXY_HOST      ""
+ENV PROXY_PORT      ""
+ENV PROXY_USER      ""
+ENV PROXY_PASS      ""
+ENV PROXY_AGENT     ""
+ENV LICENSE         ""
+ENV ADMIN_USER      "admin"
+ENV ADMIN_PASS      ""
 
 COPY nessus_startup.sh nessus_adduser.exp /usr/bin/
 COPY yum.repo /etc/yum.repos.d/Tenable.repo

--- a/nessus_startup.sh
+++ b/nessus_startup.sh
@@ -25,14 +25,15 @@ if [ ! -f /opt/nessus/var/nessus/first_run ];then
     if [ "$(/opt/nessus/sbin/nessuscli managed status | grep 'Linked to' | wc -l)" == "0" ] && [ -n "${LINKING_KEY}" ];then
         echo "-- Linking Scanner to Tenable.io"
         args=" --key=${LINKING_KEY}"
-        [ -n "${SCANNER_NAME}" ] && args=${args}" --name=${SCANNER_NAME}"
-        [ -n "${PROXY_HOST}"   ] && args=${args}" --proxy-host=${PROXY_HOST}"
-        [ -n "${PROXY_PORT}"   ] && args=${args}" --proxy-port=${PROXY_PORT}"
-        [ -n "${PROXY_USER}"   ] && args=${args}" --proxy-username=${PROXY_USER}"
-        [ -n "${PROXY_PASS}"   ] && args=${args}" --proxy-password=${PROXY_PASS}"
-        [ -n "${PROXY_AGENT}"  ] && args=${args}" --proxy-agent=${PROXY_AGENT}"
-        [ -n "${MANAGER_HOST}" ] && args=${args}" --host=${MANAGER_HOST}"        || args=${args}" --host=cloud.tenable.com"
-        [ -n "${MANAGER_PORT}" ] && args=${args}" --port=${MANAGER_PORT}"        || args=${args}" --port=443"
+        [ -n "${SCANNER_NAME}" ]    && args=${args}" --name=${SCANNER_NAME}"
+        [ -n "${SCANNER_GROUPS}" ]  && args=${args}" --groups=${SCANNER_GROUPS}"
+        [ -n "${PROXY_HOST}"   ]    && args=${args}" --proxy-host=${PROXY_HOST}"
+        [ -n "${PROXY_PORT}"   ]    && args=${args}" --proxy-port=${PROXY_PORT}"
+        [ -n "${PROXY_USER}"   ]    && args=${args}" --proxy-username=${PROXY_USER}"
+        [ -n "${PROXY_PASS}"   ]    && args=${args}" --proxy-password=${PROXY_PASS}"
+        [ -n "${PROXY_AGENT}"  ]    && args=${args}" --proxy-agent=${PROXY_AGENT}"
+        [ -n "${MANAGER_HOST}" ]    && args=${args}" --host=${MANAGER_HOST}"        || args=${args}" --host=cloud.tenable.com"
+        [ -n "${MANAGER_PORT}" ]    && args=${args}" --port=${MANAGER_PORT}"        || args=${args}" --port=443"
         /opt/nessus/sbin/nessuscli managed link ${args}
 
     elif [ -n "${LICENSE}" ];then


### PR DESCRIPTION
# Summary

Attempting to group our scanners into groups and there doesn't seem to be an option for this in the current image on https://hub.docker.com/r/tenableofficial/nessus/tags

# Changes 

Added option to add scanner to scanner groups when created. Found the command on https://docs.tenable.com/nessus/Content/NessusCLI.htm 

# Testing 

Tested this locally and didn't see any odd behavioral changes. 
